### PR TITLE
feat: Add static endpoints for LLM data



### DIFF
--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -1,11 +1,16 @@
-import type { APIRoute } from 'astro';
-import { getCollection } from 'astro:content';
+import type { APIRoute } from "astro";
+import { getCollection } from "astro:content";
 
-export const GET: APIRoute = async ({ }) => {
-  const aboutEntries = await getCollection('about');
-  const worksEntries = await getCollection('works');
+export const GET: APIRoute = async ({}) => {
+  const aboutEntries = await getCollection("about");
+  const worksEntries = await getCollection("works");
 
-  let output = '# About\n\n';
+  let output = `ここはarrow2nd (あろー)のポートフォリオサイトです。
+ここにない情報を知りたい場合は、「arrow2nd」で検索してください。
+
+# About
+
+`;
 
   // Process "about" entries
   if (aboutEntries.length > 0 && Array.isArray(aboutEntries[0].data)) {
@@ -15,9 +20,9 @@ export const GET: APIRoute = async ({ }) => {
     });
   }
 
-  output += '\n---\n\n'; // Markdown horizontal rule between About and Works
+  output += "\n---\n\n"; // Markdown horizontal rule between About and Works
 
-  output += '# Works\n\n';
+  output += "# Works\n\n";
 
   // Process "works" entries
   if (worksEntries.length > 0) {
@@ -34,17 +39,21 @@ export const GET: APIRoute = async ({ }) => {
         });
       }
 
-      if (work.data.links && Array.isArray(work.data.links) && work.data.links.length > 0) {
-        output += '### Links\n';
+      if (
+        work.data.links &&
+        Array.isArray(work.data.links) &&
+        work.data.links.length > 0
+      ) {
+        output += "### Links\n";
         work.data.links.forEach((link: any) => {
           output += `- [${link.label}](${link.href})\n`;
         });
-        output += '\n'; // Add a newline after the list for spacing
+        output += "\n"; // Add a newline after the list for spacing
       }
 
       // Add a separator between work items, but not after the last one
       if (index < worksEntries.length - 1) {
-        output += '\n---\n\n';
+        output += "\n---\n\n";
       }
     });
   }
@@ -54,7 +63,7 @@ export const GET: APIRoute = async ({ }) => {
     headers: {
       // As per instruction, keeping text/plain due to .txt extension,
       // but content is Markdown.
-      'Content-Type': 'text/plain; charset=utf-8',
+      "Content-Type": "text/plain; charset=utf-8",
     },
   });
 };

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,11 +1,15 @@
-import type { APIRoute } from 'astro';
-import { getCollection } from 'astro:content';
+import type { APIRoute } from "astro";
+import { getCollection } from "astro:content";
 
-export const GET: APIRoute = async ({ }) => {
-  const aboutEntries = await getCollection('about');
-  const worksEntries = await getCollection('works');
+export const GET: APIRoute = async ({}) => {
+  const aboutEntries = await getCollection("about");
+  const worksEntries = await getCollection("works");
 
-  let output = '# About\n\n';
+  let output = `ここはarrow2nd (あろー)のポートフォリオサイトです。
+
+# About
+
+`;
 
   // Process "about" entries
   if (aboutEntries.length > 0 && Array.isArray(aboutEntries[0].data)) {
@@ -15,9 +19,9 @@ export const GET: APIRoute = async ({ }) => {
     });
   }
 
-  output += '\n---\n\n'; // Markdown horizontal rule
+  output += "\n---\n\n"; // Markdown horizontal rule
 
-  output += '# Works\n\n';
+  output += "# Works\n\n";
 
   // Process "works" entries
   worksEntries.forEach((work: any) => {
@@ -30,7 +34,7 @@ export const GET: APIRoute = async ({ }) => {
     headers: {
       // As per instruction, keeping text/plain due to .txt extension,
       // but content is Markdown.
-      'Content-Type': 'text/plain; charset=utf-8',
+      "Content-Type": "text/plain; charset=utf-8",
     },
   });
 };


### PR DESCRIPTION
Adds two new static text endpoints:

- /llms.txt: Provides a summary of the 'about' information and 'works' titles with short descriptions.
- /llms-full.txt: Provides all details from 'about' and all 'works', including sections and links.

These endpoints fetch data from TOML files in `src/data/` via Astro's content collections.